### PR TITLE
Captcha element active on all forms?

### DIFF
--- a/captcha.install
+++ b/captcha.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\captcha\Entity\CaptchaPoint;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_schema().
@@ -135,12 +136,15 @@ function captcha_install() {
   }
 
   // Be friendly to your users: what to do after install?
+  // @todo Routes are not yet avaiable here. Is this message really useful, no
+  //   other module does this? Could be weird within an install profile, for
+  //   example.
   drupal_set_message(\Drupal::translation()->translate('You can now <a href="!captcha_admin">configure the CAPTCHA module</a> for your site.',
-    array('!captcha_admin' => url('admin/config/people/captcha'))), 'status');
+    array('!captcha_admin' => Url::fromUri('base://admin/config/people/captcha')->toString())), 'status');
 
   // Explain to users that page caching may be disabled.
   if ($config = \Drupal::config('system.performance')->get('cache.page.use_internal') != 0) {
     drupal_set_message(\Drupal::translation()->translate('Note that the CAPTCHA module disables <a href="!performance_admin">page caching</a> of pages that include a CAPTCHA challenge.',
-      array('!performance_admin' => url('admin/config/development/performance'))), 'warning');
+      array('!performance_admin' => Url::fromUri('admin/config/development/performance')->toString())), 'warning');
   }
 }

--- a/captcha.module
+++ b/captcha.module
@@ -11,6 +11,7 @@
 
 use Drupal\captcha\Entity\CaptchaPoint;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 
 /**
  * Constants for CAPTCHA persistence.
@@ -370,12 +371,11 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
     else {
       $captcha_element['#title'] = t('CAPTCHA: no challenge enabled');
       $captcha_element['add_captcha'] = array(
-        '#markup' => l(
+        '#markup' => \Drupal::l(
           t('Place a CAPTCHA here for untrusted users.'),
-          "admin/config/people/captcha/captcha-points/$form_id",
-          array(
+          Url::fromRoute('captcha_point.edit', array('captcha_point' => $form_id), array(
             'query' => drupal_get_destination(),
-          )
+          ))
         ),
       );
     }

--- a/captcha.module
+++ b/captcha.module
@@ -206,6 +206,12 @@ function captcha_element_process(array $element, FormStateInterface $form_state,
     // Generate a CAPTCHA and its solution
     // (note that the CAPTCHA session ID is given as third argument).
     $captcha = \Drupal::moduleHandler()->invoke($captcha_type_module, 'captcha', array('generate', $captcha_type_challenge, $captcha_sid));
+
+    // @todo Isn't this moment a bit late to figure out that we don't need CAPTCHA?
+    if(!isset($captcha)) {
+      return $element;
+    }
+
     if (!isset($captcha['form']) || !isset($captcha['solution'])) {
       // The selected module did not return what we expected: log about it and quit.
       \Drupal::logger('CAPTCHA')->error(

--- a/captcha.module
+++ b/captcha.module
@@ -337,7 +337,7 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
     if ($captcha_point !== NULL && $captcha_point->getCaptchaType()) {
       $captcha_element['#title'] = t('CAPTCHA: challenge "@type" enabled', array('@type' => $captcha_point->getCaptchaType()));
       $captcha_element['#description'] = t('Untrusted users will see a CAPTCHA here (<a href="@settings">general CAPTCHA settings</a>).',
-        array('@settings' => url('admin/config/people/captcha'))
+        array('@settings' => Url::fromRoute('captcha_settings')->toString())
       );
       $captcha_element['challenge'] = array(
         '#type' => 'item',

--- a/src/Entity/CaptchaPoint.php
+++ b/src/Entity/CaptchaPoint.php
@@ -24,7 +24,6 @@ use Drupal\captcha\CaptchaPointInterface;
  *       "delete" = "Drupal\captcha\Form\CaptchaPointDeleteForm"
  *     }
  *   },
- *   fieldable = FALSE,
  *   config_prefix = "captcha_point",
  *   admin_permission = "administer CAPTCHA settings",
  *   entity_keys = {

--- a/src/Form/CaptchaSettingsForm.php
+++ b/src/Form/CaptchaSettingsForm.php
@@ -11,6 +11,7 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -152,7 +153,7 @@ class CaptchaSettingsForm extends ConfigFormBase {
     $form['enable_stats'] = array(
       '#type' => 'checkbox',
       '#title' => $this->t('Enable statistics'),
-      '#description' => $this->t('Keep CAPTCHA related counters in the <a href="!statusreport">status report</a>. Note that this comes with a performance penalty as updating the counters results in clearing the variable cache.', array('!statusreport' => url('admin/reports/status'))),
+      '#description' => $this->t('Keep CAPTCHA related counters in the <a href="!statusreport">status report</a>. Note that this comes with a performance penalty as updating the counters results in clearing the variable cache.', array('!statusreport' => Url::fromRoute('system.status')->toString())),
       '#default_value' => $config->get('enable_stats'),
     );
 
@@ -160,9 +161,13 @@ class CaptchaSettingsForm extends ConfigFormBase {
     $form['log_wrong_responses'] = array(
       '#type' => 'checkbox',
       '#title' => $this->t('Log wrong responses'),
-      '#description' => $this->t('Report information about wrong responses to the <a href="!dblog">log</a>.', array('!dblog' => url('admin/reports/dblog'))),
+      '#description' => $this->t('Report information about wrong responses to the log.'),
       '#default_value' => $config->get('log_wrong_responses'),
     );
+    // Replace the description with a link if dblog.module is enabled.
+    if (\Drupal::moduleHandler()->moduleExists('dblog')) {
+      $form['#description'] = $this->t('Report information about wrong responses to the <a href="!dblog">log</a>.', array('!dblog' => Url::fromRoute('dblog.overview')->toString()));
+    }
 
     // Submit button.
     $form['actions'] = array('#type' => 'actions');


### PR DESCRIPTION
There's an error in logger showing following:
CAPTCHA problem: unexpected result from hook_captcha() of module when trying to retrieve challenge type for form user_login_form.
Can be quite spammy as it's showing every time there's any form.
Temporary fix is check whether $captcha element exists at all.
