### PR TITLE
Chasing HEAD, enabling tests, fixing some tests

### DIFF
--- a/captcha.info.yml
+++ b/captcha.info.yml
@@ -2,9 +2,8 @@ name: CAPTCHA
 type: module
 description: Provides the CAPTCHA API for adding challenges to arbitrary forms.
 package: Spam control
-version: 8.x
 core: 8.x
-configure: admin/config/people/captcha
+configure: captcha_settings
 
 dependencies:
   - node

--- a/captcha.install
+++ b/captcha.install
@@ -98,7 +98,7 @@ function captcha_requirements($phase) {
     $requirements['captcha_wrong_response_counter'] = array(
       'title' => \Drupal::translation()->translate('CAPTCHA'),
       'value' => \Drupal::translation()->formatPlural(
-        $config->get('wrong_response_counter'),
+        \Drupal::state()->get('captcha.wrong_response_counter'),
         'Already 1 blocked form submission',
         'Already @count blocked form submissions'
       ),

--- a/captcha.module
+++ b/captcha.module
@@ -292,15 +292,15 @@ function template_preprocess_captcha(&$variables) {
  */
 function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
   $account = \Drupal::currentUser();
+  $config = \Drupal::config('captcha.settings');
+  // Visitor does not have permission to skip CAPTCHAs.
+  module_load_include('inc', 'captcha');
   if (!$account->hasPermission('skip CAPTCHA')) {
-    // Visitor does not have permission to skip CAPTCHAs.
-    module_load_include('inc', 'captcha');
 
     /* @var CaptchaPoint $captcha_point */
     $captcha_point = \Drupal::entityManager()->getStorage('captcha_point')->load($form_id);
 
     if ($captcha_point) {
-      module_load_include('inc', 'captcha');
       // Build CAPTCHA form element.
       $captcha_element = array(
         '#type' => 'captcha',
@@ -308,7 +308,7 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
       );
 
       // Add a CAPTCHA description if required.
-      if (\Drupal::config('captcha.settings')->get('add_captcha_description')) {
+      if ($config->get('add_captcha_description')) {
         $captcha_element['#description'] = _captcha_get_description();
       }
 
@@ -317,11 +317,9 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
       _captcha_insert_captcha_element($form, $captcha_placement, $captcha_element);
     }
   }
-  elseif (\Drupal::config('captcha.settings')->get('administration_mode', FALSE)
-    && $account->hasPermission('administer CAPTCHA settings')
-    && (\Drupal::service('router.admin_context')->isAdminRoute()  || \Drupal::config('captcha.settings')->get('allow_on_admin_pages', FALSE))) {
+  elseif ($config->get('administration_mode') && $account->hasPermission('administer CAPTCHA settings')
+    && (!\Drupal::service('router.admin_context')->isAdminRoute()  || $config->get('allow_on_admin_pages'))) {
     // Add CAPTCHA administration tools.
-    module_load_include('inc', 'captcha');
 
     /* var $captcha_point CaptchaPoint */
     $captcha_point = captcha_get_form_id_setting($form_id);
@@ -345,8 +343,8 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
         '#title' => t('Enabled challenge'),
         '#markup' => t('%type (<a href="@change">change</a>, <a href="@disable">disable</a>)', array(
           '%type' => $captcha_point->getCaptchaType(),
-          '@change' => url("admin/config/people/captcha/captcha-points/$form_id", array('query' => drupal_get_destination())),
-          '@disable' => url("admin/config/people/captcha/captcha-points/$form_id/disable", array('query' => drupal_get_destination())),
+          '@change' => $captcha_point->url('edit-form', array('query' => drupal_get_destination())),
+          //'@disable' => url("admin/config/people/captcha/captcha-points/$form_id/disable", array('query' => drupal_get_destination())),
         )),
       );
 //      // Add an example challenge with solution.
@@ -374,8 +372,8 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
       $captcha_element['add_captcha'] = array(
         '#markup' => \Drupal::l(
           t('Place a CAPTCHA here for untrusted users.'),
-          Url::fromRoute('captcha_point.edit', array('captcha_point' => $form_id), array(
-            'query' => drupal_get_destination(),
+          Url::fromRoute('captcha_point.add', [], array(
+            'query' => drupal_get_destination() + array('form_id' => $form_id),
           ))
         ),
       );

--- a/captcha.module
+++ b/captcha.module
@@ -606,7 +606,7 @@ function captcha_validate($element, FormStateInterface &$form_state) {
       $form_state->setErrorByName('captcha_response', t('The answer you entered for the CAPTCHA was not correct.'));
       // Update wrong response counter.
       if (\Drupal::config('captcha.settings')->get('enable_stats', FALSE)) {
-        Drupal::state()->set('wrong_response_counter', Drupal::state()->get('wrong_response_counter', 0) + 1);
+        Drupal::state()->set('captcha.wrong_response_counter', Drupal::state()->get('captcha.wrong_response_counter', 0) + 1);
       }
 
       if (\Drupal::config('captcha.settings')->get('log_wrong_responses', FALSE)) {

--- a/config/install/captcha.settings.yml
+++ b/config/install/captcha.settings.yml
@@ -7,5 +7,3 @@ default_validation: 1
 persistence: 1
 enable_stats: 0
 log_wrong_responses: 0
-wrong_response_counter: 0
-image_captcha_fonts_preview_map_cache: []

--- a/src/Form/CaptchaPointForm.php
+++ b/src/Form/CaptchaPointForm.php
@@ -24,10 +24,17 @@ class CaptchaPointForm extends EntityForm {
     /* @var CaptchaPointInterface $captchaPoint */
     $captcha_point = $this->entity;
 
+    // Support to set a default form_id through a query argument.
+    $request = \Drupal::request();
+    if ($captcha_point->isNew() && !$captcha_point->id() && $request->query->has('form_id')) {
+      $captcha_point->set('formId', $request->query->get('form_id'));
+      $captcha_point->set('label', $request->query->get('form_id'));
+    }
+
     $form['label'] = array(
       '#type' => 'textfield',
       '#title' => $this->t('Form ID'),
-      '#default_value' => $captcha_point->id(),
+      '#default_value' => $captcha_point->label(),
     );
 
     $form['formId'] = array(
@@ -58,13 +65,13 @@ class CaptchaPointForm extends EntityForm {
     $captcha_point = $this->entity;
     $status = $captcha_point->save();
 
-    if ($status) {
-      drupal_set_message($this->t('Captcha Point for %label form was saved.', array(
+    if ($status == SAVED_NEW) {
+      drupal_set_message($this->t('Captcha Point for %label form was created.', array(
         '%label' => $captcha_point->label(),
       )));
     }
     else {
-      drupal_set_message($this->t('Captcha Point for %label form was not saved.', array(
+      drupal_set_message($this->t('Captcha Point for %label form was updated.', array(
         '%label' => $captcha_point->label(),
       )));
     }

--- a/src/Tests/CaptchaAdminTestCase.php
+++ b/src/Tests/CaptchaAdminTestCase.php
@@ -20,17 +20,6 @@ use stdClass;
 class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
 
   /**
-   * {@inheritdoc}
-   */
-  public static function getInfo() {
-    return array(
-      'name' => t('CAPTCHA administration functionality'),
-      'description' => t('Testing of the CAPTCHA administration interface and functionality.'),
-      'group' => t('CAPTCHA'),
-    );
-  }
-
-  /**
    * Test access to the admin pages.
    */
   public function testAdminAccess() {
@@ -294,7 +283,7 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
   public function testCaptchaPointAdministration() {
     // Generate CAPTCHA point data:
     // Drupal form ID should consist of lowercase alphanumerics and underscore).
-    $captcha_point_form_id = 'form_' . strtolower($this->randomName(32));
+    $captcha_point_form_id = 'form_' . strtolower($this->randomMachineName(32));
     // The Math CAPTCHA by the CAPTCHA module is always available,
     // so let's use it.
     $captcha_point_module = 'captcha';
@@ -360,7 +349,7 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
   public function testCaptchaPointAdministrationByNonAdmin() {
     // First add a CAPTCHA point (as admin).
     $this->drupalLogin($this->adminUser);
-    $captcha_point_form_id = 'form_' . strtolower($this->randomName(32));
+    $captcha_point_form_id = 'form_' . strtolower($this->randomMachineName(32));
     $captcha_point_module = 'captcha';
     $captcha_point_type = 'Math';
     $form_values = array(
@@ -383,7 +372,7 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
 
     // Try to set CAPTCHA point through
     // admin/user/captcha/captcha/captcha_point/$form_id.
-    $this->drupalGet(self::CAPTCHA_ADMIN_PATH . '/captcha/captcha_point/' . 'form_' . strtolower($this->randomName(32)));
+    $this->drupalGet(self::CAPTCHA_ADMIN_PATH . '/captcha/captcha_point/' . 'form_' . strtolower($this->randomMachineName(32)));
     $this->assertText(t('You are not authorized to access this page.'),
       'Non admin should not be able to set a CAPTCHA point');
 

--- a/src/Tests/CaptchaAdminTestCase.php
+++ b/src/Tests/CaptchaAdminTestCase.php
@@ -48,7 +48,7 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
   /**
    * Test the CAPTCHA point setting getter/setter.
    */
-  public function noTestCaptchaPointSettingGetterAndSetter() {
+  public function testCaptchaPointSettingGetterAndSetter() {
     $comment_form_id = self::COMMENT_FORM_ID;
     captcha_set_form_id_setting($comment_form_id, 'none');
     /* @var CaptchaPoint $result */
@@ -124,7 +124,7 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
   /**
    * Testing of the CAPTCHA administration links.
    */
-  public function noTestCaptchaAdminLinks() {
+  public function testCaptchaAdminLinks() {
     $this->drupalLogin($this->adminUser);
 
     // Enable CAPTCHA administration links.
@@ -208,7 +208,7 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
   /**
    * Test untrusted user posting.
    */
-  public function noTestUntrustedUserPosting() {
+  public function testUntrustedUserPosting() {
     // Set CAPTCHA on comment form.
     captcha_set_form_id_setting(self::COMMENT_FORM_ID, 'captcha/Math');
 
@@ -291,7 +291,7 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
   /**
    * Method for testing the CAPTCHA point administration.
    */
-  public function noTestCaptchaPointAdministration() {
+  public function testCaptchaPointAdministration() {
     // Generate CAPTCHA point data:
     // Drupal form ID should consist of lowercase alphanumerics and underscore).
     $captcha_point_form_id = 'form_' . strtolower($this->randomName(32));
@@ -357,7 +357,7 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
   /**
    * Method for testing the CAPTCHA point administration.
    */
-  public function noTestCaptchaPointAdministrationByNonAdmin() {
+  public function testCaptchaPointAdministrationByNonAdmin() {
     // First add a CAPTCHA point (as admin).
     $this->drupalLogin($this->adminUser);
     $captcha_point_form_id = 'form_' . strtolower($this->randomName(32));

--- a/src/Tests/CaptchaBaseWebTestCase.php
+++ b/src/Tests/CaptchaBaseWebTestCase.php
@@ -146,8 +146,8 @@ abstract class CaptchaBaseWebTestCase extends WebTestBase {
    */
   protected function getCommentFormValues() {
     $edit = array(
-      'subject[0][value]' => 'comment_subject ' . $this->randomName(32),
-      'comment_body[0][value]' => 'comment_body ' . $this->randomName(256),
+      'subject[0][value]' => 'comment_subject ' . $this->randomMachineName(32),
+      'comment_body[0][value]' => 'comment_body ' . $this->randomMachineName(256),
     );
 
     return $edit;
@@ -158,8 +158,8 @@ abstract class CaptchaBaseWebTestCase extends WebTestBase {
    */
   protected function getNodeFormValues() {
     $edit = array(
-      'title[0][value]' => 'node_title ' . $this->randomName(32),
-      'body[0][value]' => 'node_body ' . $this->randomName(256),
+      'title[0][value]' => 'node_title ' . $this->randomMachineName(32),
+      'body[0][value]' => 'node_body ' . $this->randomMachineName(256),
     );
 
     return $edit;
@@ -250,16 +250,4 @@ abstract class CaptchaBaseWebTestCase extends WebTestBase {
       ));
   }
 
-  /**
-   * Helper function to generate random names.
-   */
-  protected function randomName($length = 8) {
-    $values = array_merge(range(65, 90), range(97, 122), range(48, 57));
-    $max = count($values) - 1;
-    $str = chr(mt_rand(97, 122));
-    for ($i = 1; $i < $length; $i++) {
-      $str .= chr($values[mt_rand(0, $max)]);
-    }
-    return $str;
-  }
 }

--- a/src/Tests/CaptchaBaseWebTestCase.php
+++ b/src/Tests/CaptchaBaseWebTestCase.php
@@ -19,6 +19,8 @@
 // TODO: refactor the 'comment_body[0][value]' stuff.
 namespace Drupal\captcha\Tests;
 
+use Drupal\comment\Plugin\Field\FieldType\CommentItemInterface;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\simpletest\WebTestBase;
 use Drupal\Core\Language\Language;
 
@@ -93,9 +95,10 @@ abstract class CaptchaBaseWebTestCase extends WebTestBase {
     // Open comment for page content type.
     $this->container->get('comment.manager')->addDefaultField('node', 'page');
 
-    // @TODO do we need this in Drupal8?
     // Put comments on page nodes on a separate page.
-    // variable_set('comment_form_location_page', COMMENT_FORM_SEPARATE_PAGE);
+    $comment_field = FieldConfig::loadByName('node', 'page', 'comment');
+    $comment_field->settings['form_location'] = CommentItemInterface::FORM_SEPARATE_PAGE;
+    $comment_field->save();
   }
 
   /**

--- a/src/Tests/CaptchaPersistenceTestCase.php
+++ b/src/Tests/CaptchaPersistenceTestCase.php
@@ -17,16 +17,6 @@ namespace Drupal\captcha\Tests;
  * @group captcha
  */
 class CaptchaPersistenceTestCase extends CaptchaBaseWebTestCase {
-  /**
-   * {@inheritdoc}
-   */
-  public static function getInfo() {
-    return array(
-      'name' => t('CAPTCHA persistence functionality'),
-      'description' => t('Testing of the CAPTCHA persistence functionality.'),
-      'group' => t('CAPTCHA'),
-    );
-  }
 
   /**
    * Set up the persistence and CAPTCHA settings.

--- a/src/Tests/CaptchaSessionReuseAttackTestCase.php
+++ b/src/Tests/CaptchaSessionReuseAttackTestCase.php
@@ -19,17 +19,6 @@ namespace Drupal\captcha\Tests;
 class CaptchaSessionReuseAttackTestCase extends CaptchaBaseWebTestCase {
 
   /**
-   * {@inheritdoc}
-   */
-  public static function getInfo() {
-    return array(
-      'name' => t('CAPTCHA session reuse attack tests'),
-      'description' => t('Testing of the protection against CAPTCHA session reuse attacks.'),
-      'group' => t('CAPTCHA'),
-    );
-  }
-
-  /**
    * Assert that the CAPTCHA session ID reuse attack was detected.
    */
   protected function assertCaptchaSessionIdReuseAttackDetection() {

--- a/src/Tests/CaptchaTestCase.php
+++ b/src/Tests/CaptchaTestCase.php
@@ -15,17 +15,6 @@ namespace Drupal\captcha\Tests;
 class CaptchaTestCase extends CaptchaBaseWebTestCase {
 
   /**
-   * {@inheritdoc}
-   */
-  public static function getInfo() {
-    return array(
-      'name' => t('General CAPTCHA functionality'),
-      'description' => t('Testing of the basic CAPTCHA functionality.'),
-      'group' => t('CAPTCHA'),
-    );
-  }
-
-  /**
    * Testing the protection of the user log in form.
    */
   public function testCaptchaOnLoginForm() {


### PR DESCRIPTION
Worked a bit on captcha, made various changes, fixing the config schema and wrong usages of config instead of state, enable the disabled tests to better see where we are, fixing some tests and cleanup.

A lot of the admin tests are still not updated at all for how 8.x-1.x works but at least they no longer fail with fatal errors.
