### PR TITLE
Corrected the default config.

### DIFF
--- a/config/install/captcha.settings.yml
+++ b/config/install/captcha.settings.yml
@@ -1,7 +1,7 @@
 default_challenge: 'captcha/Math'
 description: 'This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.'
-administration_mode: TRUE
-allow_on_admin_pages: TRUE
+administration_mode: FALSE
+allow_on_admin_pages: FALSE
 add_captcha_description: TRUE
 default_validation: 1
 persistence: 1


### PR DESCRIPTION
With a recent change, when I changed the default config types to pass the schema validation, I accidentally changed two values from FALSE to TRUE. This caused the test to fail at one point, because it expected the mapping cache to be deleted, but because administration mode was turned on, the cache was immediately rebuilt after clearing it. [captcha_form_alter:321]

---

I closed the other pull request, I had two unnecessary commits in there, cleaned the commits up and now open this one.
