### PR TITLE
Fix test for multiple forms on single page

### DIFF
--- a/src/Tests/CaptchaSessionReuseAttackTestCase.php
+++ b/src/Tests/CaptchaSessionReuseAttackTestCase.php
@@ -188,16 +188,6 @@ class CaptchaSessionReuseAttackTestCase extends CaptchaBaseWebTestCase {
     // no CAPTCHA reuse detection (which could be used by user log in block).
     $this->assertCaptchaResponseAccepted();
     $this->assertText($comment_subject);
-
-    // Repeat the same to test form caching error.
-    $this->drupalGet('comment/reply/node/' . $node->id() . '/comment');
-    $edit['captcha_sid'] = $this->getCaptchaSidFromForm();
-    $edit['captcha_token'] = $this->getCaptchaTokenFromForm();
-    $edit['subject[0][value]'] = 'Second test';
-    $edit['captcha_response'] = 'Test 123';
-    $this->drupalPostForm(NULL, $edit, t('Preview'));
-    $this->assertCaptchaResponseAccepted();
-    $this->assertText($edit['subject[0][value]']);
   }
 
 }

--- a/src/Tests/CaptchaSessionReuseAttackTestCase.php
+++ b/src/Tests/CaptchaSessionReuseAttackTestCase.php
@@ -169,6 +169,8 @@ class CaptchaSessionReuseAttackTestCase extends CaptchaBaseWebTestCase {
    * Test multiple captcha widgets on single page.
    */
   public function testMultipleCaptchaProtectedFormsOnOnePage() {
+    \Drupal::service('module_installer')->install(['block']);
+    $this->drupalPlaceBlock('user_login_block');
     // Set Test CAPTCHA on comment form and login block.
     captcha_set_form_id_setting(self::COMMENT_FORM_ID, 'captcha/Test');
     captcha_set_form_id_setting('user_login_form', 'captcha/Test');
@@ -186,6 +188,16 @@ class CaptchaSessionReuseAttackTestCase extends CaptchaBaseWebTestCase {
     // no CAPTCHA reuse detection (which could be used by user log in block).
     $this->assertCaptchaResponseAccepted();
     $this->assertText($comment_subject);
+
+    // Repeat the same to test form caching error.
+    $this->drupalGet('comment/reply/node/' . $node->id() . '/comment');
+    $edit['captcha_sid'] = $this->getCaptchaSidFromForm();
+    $edit['captcha_token'] = $this->getCaptchaTokenFromForm();
+    $edit['subject[0][value]'] = 'Second test';
+    $edit['captcha_response'] = 'Test 123';
+    $this->drupalPostForm(NULL, $edit, t('Preview'));
+    $this->assertCaptchaResponseAccepted();
+    $this->assertText($edit['subject[0][value]']);
   }
 
 }


### PR DESCRIPTION
When logging in as admin, even when there is no captcha enabled for login, an error is shown notifying the user/admin. The login works anyway, but the message complains about a session reuse attack which it detected.

This fix checks if there is a captcha point for the requested form. Should there really be a session ID and token generated at all for that form?
