### PR TITLE
Remove Captcha challenge: none and use status() to en/disable Captchas

### DIFF
--- a/captcha.admin.inc
+++ b/captcha.admin.inc
@@ -11,7 +11,7 @@
  * For use as options array for a select form elements.
  *
  * @param bool $add_special_options
- *   If true: also add a 'none' and 'default' option.
+ *   If true: also add the 'default' option.
  *
  * @return array
  *   An associative array mapping "$module/$type" to
@@ -21,7 +21,6 @@
 function _captcha_available_challenge_types($add_special_options = TRUE) {
   $captcha_types = [];
   if ($add_special_options) {
-    $captcha_types['none'] = t('- No challenge -');
     $captcha_types['default'] = t('Default challenge type');
   }
 

--- a/captcha.inc
+++ b/captcha.inc
@@ -16,7 +16,6 @@ use Drupal\Core\Render\Element;
  *   the form ID to configure.
  * @param string $captcha_type
  *   The setting for the given form_id, can be:
- *   - 'none' to disable CAPTCHA,
  *   - 'default' to use the default challenge type
  *   - NULL to remove the entry for the CAPTCHA type
  *   - something of the form 'image_captcha/Image'
@@ -33,6 +32,7 @@ function captcha_set_form_id_setting($form_id, $captcha_type) {
   else {
     $captcha_point = new CaptchaPoint(['formId' => $form_id, 'captchaType' => $captcha_type], 'captcha_point');
   }
+  $captcha_point->enable();
 
   $captcha_point->save();
 }
@@ -48,8 +48,8 @@ function captcha_set_form_id_setting($form_id, $captcha_type) {
  * @return NULL|CaptchaPoint
  *   NULL if no setting is known
  *   captcha point object with fields 'module' and 'captcha_type'.
- *   If argument $symbolic is true, returns 'none', 'default'
- *   or in the form 'captcha/Math'.
+ *   If argument $symbolic is true, returns 'default' or in the
+ *   form 'captcha/Math'.
  */
 function captcha_get_form_id_setting($form_id, $symbolic = FALSE) {
   /* @var CaptchaPoint $captchaPoint */
@@ -175,15 +175,12 @@ function _captcha_get_description() {
  *
  * @param string $captcha_type
  *   representation of the CAPTCHA type,
- *   e.g. 'default', 'none', 'captcha/Math', 'image_captcha/Image'.
+ *   e.g. 'default', 'captcha/Math', 'image_captcha/Image'.
  *
  * @return array
  *   list($captcha_module, $captcha_type).
  */
 function _captcha_parse_captcha_type($captcha_type) {
-  if ($captcha_type == 'none') {
-    return [NULL, NULL];
-  }
   if ($captcha_type == 'default') {
     $captcha_type = \Drupal::config('captcha.settings')->get('default_challenge', 'captcha/Math');
   }

--- a/captcha.install
+++ b/captcha.install
@@ -128,7 +128,8 @@ function captcha_install() {
   foreach ($form_ids as $form_id) {
     $values = [
       'formId' => $form_id,
-      'captchaType' => 'none',
+      'captchaType' => 'default',
+      'status' => FALSE,
     ];
     $captcha_point = new CaptchaPoint($values, 'captcha_point');
     $captcha_point->trustData()->save();

--- a/captcha.module
+++ b/captcha.module
@@ -291,7 +291,7 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
   module_load_include('inc', 'captcha');
   if (!$account->hasPermission('skip CAPTCHA')) {
 
-    /* @var \Drupal\captcha\Entity\CaptchaPoint $captcha_point */
+    /* @var CaptchaPoint $captcha_point */
     $captcha_point = \Drupal::entityManager()->getStorage('captcha_point')->load($form_id);
 
     if ($captcha_point && $captcha_point->status()) {

--- a/captcha.module
+++ b/captcha.module
@@ -111,7 +111,7 @@ function captcha_element_info() {
   $captcha_element = [
     '#input' => TRUE,
     '#process' => ['captcha_element_process'],
-    // The type of challenge: e.g. 'default', 'none', 'captcha/Math', etc.
+    // The type of challenge: e.g. 'default', 'captcha/Math', etc.
     '#captcha_type' => 'default',
     '#default_value' => '',
     // CAPTCHA in admin mode: presolve the CAPTCHA and always show
@@ -291,10 +291,10 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
   module_load_include('inc', 'captcha');
   if (!$account->hasPermission('skip CAPTCHA')) {
 
-    /* @var CaptchaPoint $captcha_point */
+    /* @var \Drupal\captcha\Entity\CaptchaPoint $captcha_point */
     $captcha_point = \Drupal::entityManager()->getStorage('captcha_point')->load($form_id);
 
-    if ($captcha_point) {
+    if ($captcha_point && $captcha_point->status()) {
       // Build CAPTCHA form element.
       $captcha_element = [
         '#type' => 'captcha',
@@ -315,6 +315,7 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
   elseif ($config->get('administration_mode') && $account->hasPermission('administer CAPTCHA settings')
     && (!\Drupal::service('router.admin_context')->isAdminRoute()  || $config->get('allow_on_admin_pages'))) {
     // Add CAPTCHA administration tools.
+    /* @var \Drupal\captcha\Entity\CaptchaPoint $captcha_point */
     $captcha_point = CaptchaPoint::load($form_id);
 
     // For administrators: show CAPTCHA info and offer link to configure it.
@@ -377,8 +378,9 @@ function captcha_form_alter(array &$form, FormStateInterface $form_state, $form_
     }
 
     // Get placement in form and insert in form.
-    $captcha_placement = _captcha_get_captcha_placement($form_id, $form);
-    _captcha_insert_captcha_element($form, $captcha_placement, $captcha_element);
+    if ($captcha_placement = _captcha_get_captcha_placement($form_id, $form)) {
+      _captcha_insert_captcha_element($form, $captcha_placement, $captcha_element);
+    };
   }
 
   // Add a warning about caching on the Performance settings page.

--- a/src/Tests/CaptchaAdminTestCase.php
+++ b/src/Tests/CaptchaAdminTestCase.php
@@ -39,14 +39,14 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
    */
   public function testCaptchaPointSettingGetterAndSetter() {
     $comment_form_id = self::COMMENT_FORM_ID;
-    captcha_set_form_id_setting($comment_form_id, 'none');
+    captcha_set_form_id_setting($comment_form_id, 'test');
     /* @var CaptchaPoint $result */
     $result = captcha_get_form_id_setting($comment_form_id);
     $this->assertNotNull($result, 'CAPTCHA exists', 'CAPTCHA');
-    $this->assertEqual($result->getCaptchaType(), 'none', 'CAPTCHA type: none', 'CAPTCHA');
+    $this->assertEqual($result->getCaptchaType(), 'test', 'CAPTCHA type: default', 'CAPTCHA');
     $result = captcha_get_form_id_setting($comment_form_id, TRUE);
     $this->assertNotNull($result, 'CAPTCHA exists', 'CAPTCHA');
-    $this->assertEqual($result, 'none', 'Setting and symbolic getting CAPTCHA point: "none"', 'CAPTCHA');
+    $this->assertEqual($result, 'test', 'Setting and symbolic getting CAPTCHA point: "test"', 'CAPTCHA');
 
     // Set to 'default'
     captcha_set_form_id_setting($comment_form_id, 'default');
@@ -94,7 +94,7 @@ class CaptchaAdminTestCase extends CaptchaBaseWebTestCase {
    *   The form_id of the form to investigate.
    * @param string $challenge_type
    *   What the challenge type should be:
-   *   NULL, 'none', 'default' or something like 'captcha/Math'.
+   *   NULL, 'default' or something like 'captcha/Math'.
    */
   protected function assertCaptchaSetting($form_id, $challenge_type) {
     $result = captcha_get_form_id_setting(self::COMMENT_FORM_ID, TRUE);

--- a/src/Tests/CaptchaBaseWebTestCase.php
+++ b/src/Tests/CaptchaBaseWebTestCase.php
@@ -105,6 +105,7 @@ abstract class CaptchaBaseWebTestCase extends WebTestBase {
     /* @var \Drupal\captcha\Entity\CaptchaPoint $captcha_point */
     $captcha_point = \Drupal::entityManager()->getStorage('captcha_point')->load('user_login_form');
     $captcha_point->enable()->save();
+    $this->config('captcha.settings')->set('default_challenge', 'captcha/test')->save();
   }
 
   /**

--- a/src/Tests/CaptchaBaseWebTestCase.php
+++ b/src/Tests/CaptchaBaseWebTestCase.php
@@ -101,6 +101,10 @@ abstract class CaptchaBaseWebTestCase extends WebTestBase {
     $comment_field = FieldConfig::loadByName('node', 'page', 'comment');
     $comment_field->setSetting('form_location', CommentItemInterface::FORM_SEPARATE_PAGE);
     $comment_field->save();
+
+    /* @var \Drupal\captcha\Entity\CaptchaPoint $captcha_point */
+    $captcha_point = \Drupal::entityManager()->getStorage('captcha_point')->load('user_login_form');
+    $captcha_point->enable()->save();
   }
 
   /**

--- a/src/Tests/CaptchaPersistenceTestCase.php
+++ b/src/Tests/CaptchaPersistenceTestCase.php
@@ -172,6 +172,9 @@ class CaptchaPersistenceTestCase extends CaptchaBaseWebTestCase {
     $this->assertDifferentCsid($captcha_sid_initial);
 
     // Check another form.
+    /* @var \Drupal\captcha\Entity\CaptchaPoint $captcha_point */
+    $captcha_point = \Drupal::entityManager()->getStorage('captcha_point')->load('user_register_form');
+    $captcha_point->enable()->save();
     $this->drupalGet('user/register');
     $this->assertCaptchaPresence(TRUE);
     $this->assertDifferentCsid($captcha_sid_initial);

--- a/src/Tests/CaptchaTestCase.php
+++ b/src/Tests/CaptchaTestCase.php
@@ -32,7 +32,10 @@ class CaptchaTestCase extends CaptchaBaseWebTestCase {
     $this->drupalLogout();
 
     // Set a CAPTCHA on login form.
-    captcha_set_form_id_setting('user_login_form', 'captcha/Math');
+    /* @var \Drupal\captcha\Entity\CaptchaPoint $captcha_point */
+    $captcha_point = \Drupal::entityManager()->getStorage('captcha_point')->load('user_login_form');
+    $captcha_point->setCaptchaType('captcha/Math');
+    $captcha_point->enable()->save();
 
     // Check if there is a CAPTCHA on the login form (look for the title).
     $this->drupalGet('');
@@ -189,7 +192,10 @@ class CaptchaTestCase extends CaptchaBaseWebTestCase {
    */
   public function testCaptchaOnLoginBlockOnAdminPagesIssue893810() {
     // Set a CAPTCHA on login block form.
-    captcha_set_form_id_setting('user_login_form', 'captcha/Math');
+    /* @var \Drupal\captcha\Entity\CaptchaPoint $captcha_point */
+    $captcha_point = \Drupal::entityManager()->getStorage('captcha_point')->load('user_login_form');
+    $captcha_point->setCaptchaType('captcha/Math');
+    $captcha_point->enable()->save();
 
     // Enable the user login block.
     $this->drupalPlaceBlock('user_login_block', array('id' => 'login'));


### PR DESCRIPTION
This PR makes the CaptchaPoint actually use the status attribute which it inherits from Entity. I removed the challenge type `none` and use the status to decide whether the captcha is active on a form.

I updated the tests so the Captchas are enabled when they are being tested.
